### PR TITLE
Set the dobby configuration file

### DIFF
--- a/conf/machine/include/product.inc
+++ b/conf/machine/include/product.inc
@@ -31,3 +31,6 @@ VIRTUAL-RUNTIME_init_manager = "systemd"
 VIRTUAL-RUNTIME_initscripts = "systemd-compat-units"
 # This distro is used in westeros recipes
 DISTRO_FEATURES_append = " rdkshell"
+
+# Middleware layer requirements.
+DOBBY_DEVICESETTINGS_FILE = "dobby.generic.json"


### PR DESCRIPTION
Fix the middleware build failure - use the generic configuration provided by middleware layer.
Reference: https://ccp.sys.comcast.net/browse/RDK-50620 
Related PR: https://github.com/rdk-e/meta-rdk/pull/227