### PR TITLE
Fix for dangling bbappend causing parse error

### DIFF
--- a/conf/machine/raspberrypi4-64-rdke.conf
+++ b/conf/machine/raspberrypi4-64-rdke.conf
@@ -4,6 +4,9 @@
 #@DESCRIPTION: Machine configuration for running a RDKE on 64bit Raspberry Pi4
 #@RDK_FLAVOR: rdkv
 
+# Fix for BBAPPEND causes parse failure if respective BB file is not present
+BB_DANGLINGAPPENDS_WARNONLY = "true"
+
 require conf/machine/raspberrypi4-64.conf
 
 MACHINEOVERRIDES .= ":raspberrypi4-64:rpi:client:wpe:lxcsecure"


### PR DESCRIPTION
If respective BB file is not present and there is a BBAPPEND for that; it will cause build failure.
This flag will override the WARNING treated as ERROR allowing to progress the build.