### PR TITLE
RDKE-115: Reduce build time warnings

### DIFF
--- a/conf/machine/raspberrypi4-64-rdke.conf
+++ b/conf/machine/raspberrypi4-64-rdke.conf
@@ -25,4 +25,3 @@ require conf/machine/include/preferred_versions.inc
 
 require conf/profile.inc
 require conf/rdke-config.inc
-include conf/rdke-config.inc


### PR DESCRIPTION
Reason for change:
Issue: Bitbake throws below warnings

- WARNING: Duplicate inclusion for /rdke/configs/common/conf/rdke-config.inc in /rdke/product/meta-raspberrypi4/conf/machine/raspberrypi4-64-rdke.conf
- WARNING: Duplicate inclusion for /rdke/configs/common/conf/rdke-distros.inc in /rdke/configs/common/conf/rdke-config.inc
- WARNING: Duplicate inclusion for /rdke/configs/common/conf/rdke-repo-details.inc in /rdke/configs/common/conf/rdke-config.inc

Fixed by removing the duplicate inclusion
Test Steps: source and build
License: Inherited
Priority: Low

Signed-off by: Arun_madhavan@comcast.com