### PR TITLE
RDKE-143 Fix middlewar build errors

### DIFF
--- a/conf/machine/include/product.inc
+++ b/conf/machine/include/product.inc
@@ -41,6 +41,11 @@ DISTRO_FEATURES_remove = " rdk_svp"
 ## Move to common middleware configuration when its ready. Refer Comcast Jira: RDK-50625
 # To remove SecAPI dependency.
 DISTRO_FEATURES_append = " enable_icrypto_openssl open-middleware"
+DISTRO_FEATURES_remove = 'sec_manager'
 
 # To remove rdkfwupgrade package dependency
 DISTRO_FEATURES_remove = "enable_maintenance_manager ctrlm"
+
+# White list host tools for generating binary images
+WHITELIST_GPLv3 += "${MLPREFIX}dosfstools ${MLPREFIX}coreutils ${MLPREFIX}findutils"
+WHITELIST_GPL-3.0 = "${WHITELIST_GPLv3}"


### PR DESCRIPTION
sec_manager DISTRO_FEATURES should be removed to fix aamp build errors. 
dosfstools, coreutils, and findutils needs to be whitelisted to fix middelware image build errors.