### PR TITLE
RDKVREFPLT-3928: temporary workaround for RDKE-419

### DIFF
--- a/conf/machine/include/product.inc
+++ b/conf/machine/include/product.inc
@@ -51,3 +51,6 @@ DISTRO_FEATURES:remove = "enable_maintenance_manager ctrlm"
 # RDK-52444: Temporarily remove the SECUIRTY_CFLAGS -fstackprotector and fortify source 
 SECURITY_CFLAGS:remove = " -fstack-protector -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Wno-error=format-security -Wno-error=unused-result"
 SECURITY_LDFLAGS:remove = " -fstack-protector"
+
+# RDKVREFPLT-3928, RDKE-419: Until MTLS related refactoring completes.
+TARGET_CFLAGS:append = " -DNO_SUPPORT_FOR_MTLS "


### PR DESCRIPTION
Reason for Change: In fwupgrader getMtlscert() is blindly returning SUCCESS. This is failing on Community stack where MTLS support is not present. Added build flag NO_SUPPORT_FOR_MTLS in community stack until RDKE-419 gets a proper implementation. Enable that from product layer until the proper fix comes.
Test Procedure: Verify build integrity.