### PR TITLE
RDKE-413: Remove MTLS build flag

### DIFF
--- a/conf/machine/include/product.inc
+++ b/conf/machine/include/product.inc
@@ -52,8 +52,5 @@ DISTRO_FEATURES:remove = "enable_maintenance_manager"
 SECURITY_CFLAGS:remove = " -fstack-protector -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Wno-error=format-security -Wno-error=unused-result"
 SECURITY_LDFLAGS:remove = " -fstack-protector"
 
-# RDKVREFPLT-3928, RDKE-419: Until MTLS related refactoring completes.
-TARGET_CFLAGS:append = " -DNO_SUPPORT_FOR_MTLS "
-
 #Setting default build variant as debug.
 BUILD_VARIANT ?= "debug"


### PR DESCRIPTION
This is not required as per new changes in respective component