### PR TITLE
RDKVREFPLT-3946:Enable maintanence manager for RFC

### DIFF
--- a/conf/machine/include/product.inc
+++ b/conf/machine/include/product.inc
@@ -41,6 +41,9 @@ VC4DTBO = "vc4-fkms-v3d"
 # Platform does not have SVP support
 DISTRO_FEATURES:remove = " rdk_svp"
 
+# To remove autostart dependency in rdkservices
+DISTRO_FEATURES:remove = " thunder_startup_services"
+
 ## Move to common middleware configuration when its ready. Refer Comcast Jira: RDK-50625
 # To remove SecAPI dependency.
 DISTRO_FEATURES:append = " enable_icrypto_openssl"

--- a/conf/machine/include/product.inc
+++ b/conf/machine/include/product.inc
@@ -41,9 +41,6 @@ VC4DTBO = "vc4-fkms-v3d"
 # Platform does not have SVP support
 DISTRO_FEATURES:remove = " rdk_svp"
 
-# To remove autostart dependency in rdkservices
-DISTRO_FEATURES:remove = " thunder_startup_services"
-
 ## Move to common middleware configuration when its ready. Refer Comcast Jira: RDK-50625
 # To remove SecAPI dependency.
 DISTRO_FEATURES:append = " enable_icrypto_openssl"

--- a/conf/machine/include/product.inc
+++ b/conf/machine/include/product.inc
@@ -45,9 +45,6 @@ DISTRO_FEATURES:remove = " rdk_svp"
 # To remove SecAPI dependency.
 DISTRO_FEATURES:append = " enable_icrypto_openssl"
 
-# To remove rdkfwupgrade package dependency
-DISTRO_FEATURES:remove = "enable_maintenance_manager"
-
 # RDK-52444: Temporarily remove the SECUIRTY_CFLAGS -fstackprotector and fortify source 
 SECURITY_CFLAGS:remove = " -fstack-protector -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Wno-error=format-security -Wno-error=unused-result"
 SECURITY_LDFLAGS:remove = " -fstack-protector"

--- a/recipes-core/images/middleware-test-image.bbappend
+++ b/recipes-core/images/middleware-test-image.bbappend
@@ -1,0 +1,19 @@
+# workaround for partnerid 
+insert_partner_id(){
+    mkdir -p ${IMAGE_ROOTFS}/opt/www/authService
+    if [ ! -f "${IMAGE_ROOTFS}/opt/www/authService/partnerId3.dat" ]; then
+        touch ${IMAGE_ROOTFS}/opt/www/authService/partnerId3.dat
+        echo "community" > ${IMAGE_ROOTFS}/opt/www/authService/partnerId3.dat
+    fi
+}
+
+# workaround for bsp complete.ini path
+handle_bsp_complete(){
+ if [ ! -f "${IMAGE_ROOTFS}/opt/bspcomplete.ini" ]; then
+    touch ${IMAGE_ROOTFS}/opt/bspcomplete.ini
+ fi
+
+}
+
+ROOTFS_POSTPROCESS_COMMAND += "insert_partner_id; handle_bsp_complete; "
+


### PR DESCRIPTION
Reason for change: Enabled maintanencemanager as part of rdke builds, needed by RFC
Test Procedure: Build should pass
Risks: Low
Signed-off-by: Lakshmipriya Lakshmipriya_Purushan@comcast.com