### PR TITLE
RDKVREFPLT-3298 : DRM config options

### DIFF
--- a/conf/machine/include/product.inc
+++ b/conf/machine/include/product.inc
@@ -50,3 +50,5 @@ SECURITY_LDFLAGS:remove = " -fstack-protector"
 
 #Setting default build variant as debug.
 BUILD_VARIANT ?= "debug"
+
+OPENCDM_DRMS=""


### PR DESCRIPTION
Reason for change: We need to ensure that proper drm configuration is
 updated for RPI images.