### PR TITLE
REFPLTV-2287: Wpeframework is continuously restarting on displayinfo width

### DIFF
--- a/conf/machine/include/product.inc
+++ b/conf/machine/include/product.inc
@@ -4,6 +4,10 @@ MACHINE = "raspberrypi4-64-rdke"
 TARGET_VENDOR = "-rdk"
 KERNEL_IMAGETYPE= "Image"
 
+#-----------Build related flags
+MACHINE_OEM_NAME = "RaspberryPi4"
+MACHINE_SOC_NAME = "BCM2711"
+
 # To enable serial console
 ENABLE_UART = "1"
 


### PR DESCRIPTION
Reason for change: Wpeframework is continuously restarting on displayinfo width
Test Procedure: check the curl command response for DisplayInfo width
Risks: Low
Signed-off-by: Dorababu_Pragada@comcast.com