### PR TITLE
RDKE-492: Remove SoC info from plugin code

### DIFF
--- a/conf/machine/include/preferred_provider.inc
+++ b/conf/machine/include/preferred_provider.inc
@@ -30,6 +30,7 @@ PREFERRED_PROVIDER_virtual/vendor-audio-service = "audio-service-rpi"
 PREFERRED_PROVIDER_virtual/vendor-gst-drm-plugins = "gst-drm-plugins-rpi"
 PREFERRED_PROVIDER_virtual/vendor-secapi2-adapter = "secapi2-adapter-rpi"
 PREFERRED_PROVIDER_virtual/vendor-systemaudioplatform = "systemaudioplatform"
+PREFERRED_PROVIDER_virtual/vendor-displayinfo-soc = "noop"
 
 # Cobalt must be compiled from sources until REFPLTV-2693 is resolved
 PREFERRED_PROVIDER_virtual/cobalt-evergreen = "cobalt-evergreen-src"


### PR DESCRIPTION
Reason for change: Remove sensitive information for open sourcing
Test Procedure: see ticket
Risks: None
Priority: P1