### PR TITLE
PREMIUMAPP-3209 : Remove Cobalt Distros from RPI product layer

### DIFF
--- a/conf/machine/include/product.inc
+++ b/conf/machine/include/product.inc
@@ -20,10 +20,6 @@ TCLIBCAPPEND = ""
 MACHINEOVERRIDES .= ":kirkstone"
 DISTRO_FEATURES:append = " kirkstone"
 
-# TODO: PREMIUMAPP-3209: remove when common config provides these.
-DISTRO_FEATURES:append = " cobalt-25"
-DISTRO_FEATURES:append = " enable_cobalt_plugin"
-
 require conf/multilib.conf
 MULTILIBS = "multilib:lib32"
 DEFAULTTUNE:virtclass-multilib-lib32 = "armv7athf-neon-vfpv4"


### PR DESCRIPTION
Reason for change: Move generic DISTRO_FEATURES to rdkm common config
Test procedure: Refer ticket
Risks: low
Priority : P2
Signed-off-by: Ansu Mathew <Ansu_Mathew@comcast.com>