### PR TITLE
Revert "RDKVREFPLT-5332: Enable Distro to remove provisioning precondition check for OCDM plugin"

### DIFF
--- a/conf/machine/raspberrypi4-64-rdke.conf
+++ b/conf/machine/raspberrypi4-64-rdke.conf
@@ -35,6 +35,3 @@ MACHINE_IMAGE_NAME = "RPI4"
 DEVICE_MODEL_NUMBER = "RPI4"
 MACHINE_IMAGE_NAME ?= "${DEVICE_MODEL_NUMBER}"
 IMAGE_NAME ?= "${IMAGE_BASENAME}-${MACHINE_IMAGE_NAME}${IMAGE_VERSION_SUFFIX}"
-
-# Enable Distro to remove provisioning precondition check while activate OCDM plugin
-DISTRO_FEATURES:append = " disable_provision_precondition_rdkm"


### PR DESCRIPTION
Reverts rdkcentral/meta-product-raspberrypi#126
Reason: https://github.com/rdkcentral/rdke-common-config/compare/1.0.3...1.0.4 contains that fix.