### PR TITLE
RDKECOREMW-596: motion detection vendor provider config

### DIFF
--- a/conf/machine/include/preferred_provider.inc
+++ b/conf/machine/include/preferred_provider.inc
@@ -22,6 +22,7 @@ PREFERRED_PROVIDER_virtual/vendor-deepsleepmgr-hal = "deepsleepmgr-hal-raspberry
 PREFERRED_PROVIDER_virtual/mfrlib = "mfrlibs-hal-raspberrypi4"
 PREFERRED_PROVIDER_virtual/vendor-hdmicec-hal = "hdmicec-hal-raspberrypi4"
 PREFERRED_PROVIDER_virtual/vendor-tvsettings-hal = "tvsettings-hal-noop"
+PREFERRED_PROVIDER_virtual/vendor-motiondetector-hal = "motiondetector-hal-noop"
 PREFERRED_PROVIDER_virtual/vendor-rdk-gstreamer-utils-platform = "rdk-gstreamer-utils-platform"
 
 #Temp add media-utils as provider for vendor-media-utils, to be re-worked if hal changes are required.


### PR DESCRIPTION
Reason for Change: The motion detection feature is TV platform specific.