### PR TITLE
Update RPI_EXTRA_CONFIG in product.inc

### DIFF
--- a/conf/machine/include/product.inc
+++ b/conf/machine/include/product.inc
@@ -11,7 +11,13 @@ ENABLE_UART = "1"
 VC4DTBO = "vc4-kms-v3d"
 
 # Enable CPU boost for performance, ref: https://meta-raspberrypi.readthedocs.io/en/latest/extra-build-config.html
-RPI_EXTRA_CONFIG += "\narm_boost=1\nhdmi_force_hotplug:0=1\nhdmi_force_hotplug:1=0\n"
+RPI_EXTRA_CONFIG += "\n\
+enable_uart=1\n\
+dtoverlay=pi3-miniuart-bt\n\
+arm_boost=1\n\
+hdmi_force_hotplug:0=1\n\
+hdmi_force_hotplug:1=0\n\
+"
 
 # This is needed for tmp directory to be named as tmp instead of tmp-glibc
 TCLIBCAPPEND = ""


### PR DESCRIPTION
## Problem

`hciuart.service` intermittently fails during system boot with the following error:

```bash id="1g7k3h"
Can't open serial port: No such file or directory
```

The issue occurs because the Bluetooth UART interface is not configured correctly during early boot on Raspberry Pi platforms.

As a result:

* `/dev/ttyAMA0` may not become available reliably during boot
* `hciuart.service` may fail intermittently

---

## Root Cause

The Raspberry Pi Bluetooth/UART configuration was incomplete in the platform configuration.

By default:

* Bluetooth may use the PL011 UART
* UART assignment can vary depending on overlay configuration
* The expected UART device for `hciuart.service` may not initialize consistently

This leads to unreliable availability of `/dev/ttyAMA0` during boot.

---

## Solution

Updated `RPI_EXTRA_CONFIG` in `product.inc` to explicitly configure the Raspberry Pi Bluetooth UART overlay.

Added:

```conf id="y2vxz5"
enable_uart=1
dtoverlay=pi3-miniuart-bt
arm_boost=1
```

Resulting configuration:

```bitbake id="0g8kw3"
RPI_EXTRA_CONFIG += "\n\
enable_uart=1\n\
dtoverlay=pi3-miniuart-bt\n\
arm_boost=1\n\
hdmi_force_hotplug:0=1\n\
hdmi_force_hotplug:1=0\n\
"
```

---

## Implementation

Updated:

```text id="om5vxf"
product.inc
```

Modified:

```text id="5f6cnq"
RPI_EXTRA_CONFIG
```

to include:

* `enable_uart=1`
* `dtoverlay=pi3-miniuart-bt`

---

## Configuration Details

### `enable_uart=1`

* Ensures UART support is enabled on Raspberry Pi
* Allows Bluetooth communication over UART

### `dtoverlay=pi3-miniuart-bt`

* Switches Bluetooth to use the mini UART
* Frees PL011 UART for stable system usage

### `arm_boost=1`

* Maintains stable CPU frequency behavior required for reliable mini UART operation

---

## Result

* Improves UART initialization reliability during boot
* Ensures stable availability of `/dev/ttyAMA0`
* Reduces intermittent `hciuart.service` failures
* Improves Bluetooth initialization consistency across reboots
